### PR TITLE
update githubchart version to fix bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'http://rubygems.org'
 ruby "2.6.6"
 gem 'sinatra'
-gem 'githubchart', '>= 3.4.0'
+gem 'githubchart', '>= 4.0.0'


### PR DESCRIPTION
Due to changes in the github api lead to some internal server error problems  #34 and #33, the current gem library githubchart has been updated to fix the problem [“update githubstats dep"](https://github.com/akerl/githubchart/commit/457c72299862e0f20ac44e2762a90cc5bf9ad1fc), now update githubchart to the latest version 4.0.0 can solve the problem.